### PR TITLE
fix bug in ema_vfi

### DIFF
--- a/basic_infer/archs/ema_vfi/model/warplayer.py
+++ b/basic_infer/archs/ema_vfi/model/warplayer.py
@@ -1,9 +1,10 @@
 import torch
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+# device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 backwarp_tenGrid = {}
 
 def warp(tenInput, tenFlow):
+    device = tenFlow.device
     k = (str(tenFlow.device), str(tenFlow.size()))
     if k not in backwarp_tenGrid:
         tenHorizontal = torch.linspace(-1.0, 1.0, tenFlow.shape[3], device=device).view(


### PR DESCRIPTION
I found a bug when computing ema_vfi in parallel with multiple GPUs. 

Due to the fact that in the case of multiple GPUs, the backwarp_tenGrid [k] is located at cuda:0, and the tenFlow may be located at cuda:x (x>0). This can lead to some videos being unable to insert frames properly after partitioning, resulting in abnormal final results such as reduced duration and frame loss.